### PR TITLE
Bump `browserstacktunnel-wrapper` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "browserstacktunnel-wrapper": "~1.1.2"
+    "browserstacktunnel-wrapper": "~1.3.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",


### PR DESCRIPTION
The latest includes newer binaries which auto-download on first install. Mostly motivated to bump the versions because the current version doesn't work on a clean ubuntu server install out of the box.
